### PR TITLE
added int quitFlag() in poll loop to update when client QUIT

### DIFF
--- a/include/server.hpp
+++ b/include/server.hpp
@@ -6,7 +6,7 @@
 /*   By: htran-th <htran-th@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/25 10:32:41 by siuol             #+#    #+#             */
-/*   Updated: 2025/08/11 19:26:22 by htran-th         ###   ########.fr       */
+/*   Updated: 2025/08/11 20:36:52 by htran-th         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ class Server
         int     getIndex(int fd) const;
         
         //Exec
-        void    parseCommand(Client* client, std::string& command);
+        void    parseCommand(Client* client, std::string& command, int& quitFlag);
 
     private :
         int                              _server_fd;

--- a/src/parser/parseGeneral.cpp
+++ b/src/parser/parseGeneral.cpp
@@ -6,7 +6,7 @@
 /*   By: htran-th <htran-th@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/31 10:47:44 by siuol             #+#    #+#             */
-/*   Updated: 2025/08/11 19:12:22 by htran-th         ###   ########.fr       */
+/*   Updated: 2025/08/11 20:36:38 by htran-th         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,7 @@ void    Server::execCommand(Client* client, std::string cmd, std::string fullCom
         Notifyer::notifyError(client, 421);
 }
 
-void    Server::parseCommand(Client* client, std::string& command)
+void    Server::parseCommand(Client* client, std::string& command, int& quitFlag)
 {
     if (command.empty())
     {
@@ -70,7 +70,11 @@ void    Server::parseCommand(Client* client, std::string& command)
     if (cmdPack.size() == 0)
         return ;
     if (cmdPack[0] == "QUIT")
+    {
         this->parseQuit(client, command);
+        quitFlag = 0;
+        return ;
+    }
     if (client->getStatus() != COMPLETE)
     {
         this->parseSign(client, command);

--- a/src/server/infras/sv_poll_and_accept.cpp
+++ b/src/server/infras/sv_poll_and_accept.cpp
@@ -6,7 +6,7 @@
 /*   By: htran-th <htran-th@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/06 21:00:42 by htran-th          #+#    #+#             */
-/*   Updated: 2025/08/11 19:08:18 by htran-th         ###   ########.fr       */
+/*   Updated: 2025/08/11 20:36:20 by htran-th         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,7 @@ void Server::removeClient(int client_fd, int index)
 }
 
 void Server::pollAndAccept() {
+    int quitFlag  = 0;
     std::signal(SIGINT, signal_handler);
     std::signal(SIGQUIT, signal_handler);
     pollfd s_pfd = {.fd = _server_fd, .events = POLLIN, .revents = 0};
@@ -96,7 +97,7 @@ void Server::pollAndAccept() {
                 if (bytesRead <= 0) {
                     if (errno == EINTR)
                         continue;
-                    std::cerr << RED << "Client disconnected: fd = " << client_fd << RESET << std::endl;
+                    std::cout << RED << "Client disconnected: fd = " << client_fd << RESET << std::endl;
                     removeClient(client_fd, i);
                     --i; // because the rest of the array shifted one place to the left
                     continue ; // checks the rest of the clients
@@ -106,8 +107,15 @@ void Server::pollAndAccept() {
                 if (!message.empty())
                 { 
                     Client *client = _socketList[client_fd];
-                    parseCommand(client, message);
+                    parseCommand(client, message, quitFlag);
                     std::cout << "Message from client(fd " << client_fd << "): " << buffer << std::endl; // Temporarily here - delete later
+                    if (quitFlag)
+                    {
+                        --i;
+                        quitFlag = 0;
+                        std::cout << RED << "Client disconnected: fd = " << client_fd << RESET << std::endl;
+                        continue;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- When client type "QUIT", Server removes client manually -> still needs to update (in poll loop) and print out proper message.
- When client quits -> not an error, change the output messages to std::cout.