### PR TITLE
Issue: unregistered client not being cleaned up when server quits.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,6 +71,11 @@
         "mutex": "cpp",
         "ratio": "cpp",
         "variant": "cpp",
-        "format": "cpp"
+        "format": "cpp",
+        "csignal": "cpp",
+        "iomanip": "cpp",
+        "span": "cpp",
+        "text_encoding": "cpp",
+        "cinttypes": "cpp"
     }
 }

--- a/include/server.hpp
+++ b/include/server.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   server.hpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: siuol <siuol@student.42.fr>                +#+  +:+       +#+        */
+/*   By: htran-th <htran-th@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/25 10:32:41 by siuol             #+#    #+#             */
-/*   Updated: 2025/08/13 23:17:12 by siuol            ###   ########.fr       */
+/*   Updated: 2025/08/15 18:29:45 by htran-th         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@ class Server
         void    initSocket();
         void    bindAndListen();
         void    pollAndAccept();
+        void    gracefullyShutDown();
         void    removeClient(int client_fd, int index);
         void    closeAllFds();
         int     getIndex(int fd) const;

--- a/src/server/implementation/serverClean.cpp
+++ b/src/server/implementation/serverClean.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   serverClean.cpp                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: htran-th <htran-th@student.42.fr>          +#+  +:+       +#+        */
+/*   By: htran-th <htran-th@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/06 02:18:31 by siuol             #+#    #+#             */
-/*   Updated: 2025/08/06 20:49:32 by htran-th         ###   ########.fr       */
+/*   Updated: 2025/08/15 20:36:57 by htran-th         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,18 +30,32 @@ Server::~Server()
         delete channel;
     }
     
-    for (auto& pair : _clientList)
-    {
-        Client* client = pair.second;
+    // for (auto& pair : _clientList)
+    // {
+    //     Client* client = pair.second;
         
-        delete client;
-    }
+    //     delete client;
+    // }
 
-    closeAllFds();
+    // closeAllFds();
     
     this->_channelList.clear();
     this->_clientList.clear();
-    this->_socketList.clear();
+    // this->_socketList.clear();
+
+    for (size_t i = 1; i < _poll_fds.size(); ++i) {
+        int fd = _poll_fds[i].fd;
+        close(fd);
+        if (std::map<int,Client*>::iterator it = _socketList.find(fd);
+            it != _socketList.end()) {
+            delete it->second;
+            _socketList.erase(it);
+        }
+    }
+    _poll_fds.clear();
+    if (_server_fd >= 0) {
+        close(_server_fd); _server_fd = -1;
+    }
 
     std::cout << "Shutting down server!" << std::endl;
 }

--- a/src/server/infras/sv_poll_and_accept.cpp
+++ b/src/server/infras/sv_poll_and_accept.cpp
@@ -6,7 +6,7 @@
 /*   By: htran-th <htran-th@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/06 21:00:42 by htran-th          #+#    #+#             */
-/*   Updated: 2025/08/11 20:36:20 by htran-th         ###   ########.fr       */
+/*   Updated: 2025/08/15 20:41:12 by htran-th         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,8 +64,9 @@ void Server::pollAndAccept() {
     while (g_running) {
         int ret = poll(_poll_fds.data(), _poll_fds.size(), -1);
         if (ret < 0) {
-            if (errno == EINTR)
+            if (errno == EINTR) {
                 continue; // g_running now changed -> break
+            }
             throw std::runtime_error("Server: poll failed!");
         }
         if (_poll_fds[0].revents & POLLIN) {


### PR DESCRIPTION
Issue:
        - Client connected to Server, not yet registered.
	- Server quits with signal (SIGINT/SIGQUIT) causing leaks.
Reason:
	- Server destructor: prioritizes delete based on _clientList (contains registered clients) and only .clear() _socketList (contains both unregistered/registered clients). 
Fix:
	- Server destructor: delete clients based on _socketList.
	- .clear() _clientList.